### PR TITLE
Merchant bulk discount delete

### DIFF
--- a/app/controllers/bulk_discounts_controller.rb
+++ b/app/controllers/bulk_discounts_controller.rb
@@ -23,6 +23,12 @@ class BulkDiscountsController < ApplicationController
     end
   end
 
+  def destroy
+    @merchant = Merchant.find(params[:merchant_id])
+    BulkDiscount.destroy(params[:id])
+    redirect_to merchant_bulk_discounts_path(@merchant)
+  end
+
   private
 
   def bulk_discount_params

--- a/app/views/bulk_discounts/index.html.erb
+++ b/app/views/bulk_discounts/index.html.erb
@@ -8,6 +8,7 @@
       <h3>Percentage Discount: <%= bulk_discount.percent_discount %></h3>
       <h3>Item Quantity Threshold: <%= bulk_discount.item_threshold %></h3>
       <h3>Bulk Discount #<%= link_to "#{bulk_discount.id}", merchant_bulk_discounts_path(@merchant.id, bulk_discount.id) %> </h3>
+      <h3><%= link_to "Delete Bulk Discount", merchant_bulk_discount_path(@merchant.id, bulk_discount.id), method: :delete %> </h3>
       <hr>
     </li>
   <% end %>

--- a/spec/features/merchants/bulk_discount_delete_spec.rb
+++ b/spec/features/merchants/bulk_discount_delete_spec.rb
@@ -1,0 +1,37 @@
+require "rails_helper"
+
+RSpec.describe "Merchant Bulk Discount Delete" do
+  before :each do
+    @merchant1 = Merchant.create!(name: 'Hair Care')
+    @bulk_discount_1 = BulkDiscount.create!(item_threshold: 5, percent_discount: 0.05, name:'Senior Day Discount', merchant_id: @merchant1.id)
+    @bulk_discount_2 = BulkDiscount.create!(item_threshold: 10, percent_discount: 0.10, name:'Christmas Discount', merchant_id: @merchant1.id)
+    @bulk_discount_3 = BulkDiscount.create!(item_threshold: 15, percent_discount: 0.15, name:' 4th of July Discount', merchant_id: @merchant1.id)
+    @bulk_discount_4 = BulkDiscount.create!(item_threshold: 20, percent_discount: 0.20, name:'Halloween Discount', merchant_id: @merchant1.id)
+  end
+
+  describe "When I visit my bulk discounts index page" do
+    it "can delete each bulk discount when clicking the 'Delete' link" do
+      VCR.use_cassette("bulk_discount_creation") do
+        visit "/merchant/#{@merchant1.id}/bulk_discounts"
+
+        within(".bulk-discount-info-#{@bulk_discount_1.id}") do
+          expect(page).to have_link("Delete Bulk Discount")
+        end
+        within(".bulk-discount-info-#{@bulk_discount_2.id}") do
+          expect(page).to have_link("Delete Bulk Discount")
+        end
+        within(".bulk-discount-info-#{@bulk_discount_3.id}") do
+          expect(page).to have_link("Delete Bulk Discount")
+        end
+        within(".bulk-discount-info-#{@bulk_discount_4.id}") do
+          expect(page).to have_link("Delete Bulk Discount")
+
+          click_link("Delete Bulk Discount")
+        end
+
+        expect(current_path).to eq("/merchant/#{@merchant1.id}/bulk_discounts")
+        expect(page).to_not have_content(@bulk_discount_4.name)
+      end
+    end
+  end
+end


### PR DESCRIPTION
Finished user story 4 for deleting a Merchant's Bulk Discount
Update the BulkDiscounts Controller with the destroy action and redirect back to the Bulk Discount index page for a merchant once a Bulk Discount has been deleted
Added the link_to Delete Bulk Discount in the index view for a merchant's bulk discount
