### PR TITLE
Merchant bulk discount show

### DIFF
--- a/app/controllers/bulk_discounts_controller.rb
+++ b/app/controllers/bulk_discounts_controller.rb
@@ -4,6 +4,10 @@ class BulkDiscountsController < ApplicationController
     @public_holidays = NagerDateService.new("US").next_public_holidays
   end
 
+  def show
+    @bulk_discount= BulkDiscount.find(params[:id])
+  end
+
   def new
     @merchant = Merchant.find(params[:merchant_id])
   end

--- a/app/views/bulk_discounts/show.html.erb
+++ b/app/views/bulk_discounts/show.html.erb
@@ -1,0 +1,3 @@
+<h1><%= @bulk_discount.name %></h1><br>
+<h3>Item Threshold: <%= @bulk_discount.item_threshold %></h3><hr>
+<h3>Percent Discount: <%= @bulk_discount.percent_discount %></h3><hr>

--- a/spec/features/merchants/bulk_discount_show_spec.rb
+++ b/spec/features/merchants/bulk_discount_show_spec.rb
@@ -1,0 +1,24 @@
+require "rails_helper"
+
+RSpec.describe "Merchant Bulk Discount Show" do
+  before :each do
+    @merchant1 = Merchant.create!(name: 'Hair Care')
+    @bulk_discount_1 = BulkDiscount.create!(item_threshold: 5, percent_discount: 0.05, name:'Senior Day Discount', merchant_id: @merchant1.id)
+    @bulk_discount_2 = BulkDiscount.create!(item_threshold: 10, percent_discount: 0.10, name:'Christmas Discount', merchant_id: @merchant1.id)
+    @bulk_discount_3 = BulkDiscount.create!(item_threshold: 15, percent_discount: 0.15, name:' 4th of July Discount', merchant_id: @merchant1.id)
+    @bulk_discount_4 = BulkDiscount.create!(item_threshold: 20, percent_discount: 0.20, name:'Halloween Discount', merchant_id: @merchant1.id)
+  end
+
+  describe "When I visit my bulk discount show page" do
+    it "can display the bulk discount item threshold and percent discount" do
+      VCR.use_cassette("bulk_discount_creation") do
+        visit "/merchant/#{@merchant1.id}/bulk_discounts/#{@bulk_discount_1.id}"
+
+        expect(page).to have_content(@bulk_discount_1.item_threshold)
+        expect(page).to have_content(@bulk_discount_1.percent_discount)
+        expect(page).to_not have_content(@bulk_discount_2.item_threshold)
+        expect(page).to_not have_content(@bulk_discount_2.percent_discount)
+      end
+    end
+  end
+end


### PR DESCRIPTION
Created the feature spec and got it passing for a Merchant Bulk Discount show page
It renders the item threshold and percent discount, as well as a header for the name of the discount to the show view page
Updated the BulkDiscountsController to include the show action
Verified with tests that only one bulk discount shows up per show page