### PR TITLE
Link to applied discounts

### DIFF
--- a/app/views/invoices/show.html.erb
+++ b/app/views/invoices/show.html.erb
@@ -47,6 +47,9 @@
                                             <%= f.select :status, Invoice.statuses.keys, selected: "#{@invoice.status}" %>
                                             <%= f.submit 'Update Invoice' %>
                                           <% end %></td><br/>
+            <% if i.available_discount %>
+              <td style="text-align:center"><%= link_to "View Bulk Discount Applied", merchant_bulk_discount_path(@merchant) %>
+            <% end %>
           </tr>
         </section>
       <% end %>

--- a/spec/features/invoices/show_spec.rb
+++ b/spec/features/invoices/show_spec.rb
@@ -142,7 +142,6 @@ RSpec.describe 'invoices show' do
         visit "/merchant/#{@merchant1.id}/invoices/#{@invoice_1.id}"
 
         expect(page).to have_link("View Bulk Discount Applied")
-        save_and_open_page
       end
     end
   end

--- a/spec/features/invoices/show_spec.rb
+++ b/spec/features/invoices/show_spec.rb
@@ -136,5 +136,14 @@ RSpec.describe 'invoices show' do
         expect(page).to have_content("Total Revenue: 234.0")
       end
     end
+
+    it "displays a link next to each invoice item that links user to show page for bulk discount if applied" do
+      VCR.use_cassette("bulk_discount_creation") do
+        visit "/merchant/#{@merchant1.id}/invoices/#{@invoice_1.id}"
+
+        expect(page).to have_link("View Bulk Discount Applied")
+        save_and_open_page
+      end
+    end
   end
 end


### PR DESCRIPTION
Add feature spec for user story adding a link to the merchant invoice show page to view the bulk discount applied to an invoice item

Added the link and logic in the invoices show page to only produce the link for bulk discount applied if the invoice item met the bulk discount quantity threshold